### PR TITLE
fix: 채팅 히스토리 커서 페이지네이션 응답 구조 반영

### DIFF
--- a/CATXI-FE/src/hooks/chatConnect/useChatConnection.ts
+++ b/CATXI-FE/src/hooks/chatConnect/useChatConnection.ts
@@ -60,8 +60,8 @@ export function useChatConnection(roomId: number) {
   const [coordinates, setCoordinates] = useState<ApiMember[]>([]);
 
   useEffect(() => {
-    if (chatHistory?.data && email) {
-      setMessages(mapChatHistoryToMessages(chatHistory.data, email));
+    if (chatHistory?.data?.messages && email) {
+      setMessages(mapChatHistoryToMessages(chatHistory.data.messages, email));
     }
   }, [chatHistory, email, setMessages]);
 

--- a/CATXI-FE/src/types/chat/chatData.ts
+++ b/CATXI-FE/src/types/chat/chatData.ts
@@ -35,6 +35,12 @@ export interface ChatMessageItem {
   sentAt: string;
 };
 
+export interface ChatMessagePageData {
+  messages: ChatMessageItem[];
+  nextCursor: number | null;
+  hasNext: boolean;
+}
+
 export interface ChatRoomItem {
     roomId: number;
     hostId: number;
@@ -63,7 +69,7 @@ export interface ChatRoomData {
   myRoomId: number;
   rooms: ChatRoomList;
 }
- 
-export type ChatMessagesResponse = ApiResponse<ChatMessageItem[]>;
+
+export type ChatMessagesResponse = ApiResponse<ChatMessagePageData>;
 
 export type ChatRoomResponse = ApiResponse<ChatRoomData>;


### PR DESCRIPTION
## 문제

커서 기반 페이지네이션 도입 후 백엔드 응답 구조가 변경되었으나 프론트엔드가 기존 배열 형태를 그대로 사용하고 있어 `TypeError: items.map is not a function` 발생 → `GlobalErrorPage`("세션이 만료되었습니다.") 렌더링

**변경 전 응답**
```json
{ "data": [ { "messageId": 1, ... } ] }
```

**변경 후 응답**
```json
{ "data": { "messages": [...], "nextCursor": null, "hasNext": false } }
```

## 변경 사항

- `ChatMessagesResponse` 타입을 `ApiResponse<ChatMessageItem[]>` → `ApiResponse<ChatMessagePageData>`로 변경
- `ChatMessagePageData` 인터페이스 추가 (`messages`, `nextCursor`, `hasNext`)
- `useChatConnection`에서 `chatHistory.data` → `chatHistory.data.messages` 로 수정

## 영향 범위

- 채팅방 입장 시 이전 메시지 히스토리 로드
- 커서 기반 페이지네이션 구조 유지 (`nextCursor`, `hasNext` 활용 가능)